### PR TITLE
Add TestDrive versions of the Jupyter notebook files

### DIFF
--- a/src/analytics/CreateCredentials_TestDrive.ipynb
+++ b/src/analytics/CreateCredentials_TestDrive.ipynb
@@ -1,0 +1,85 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "!sudo pip2.7 install --extra-index-url https://analytics-tool-kit.s3-us-west-2.amazonaws.com/public/weekly/regressed/latest/archive/trustedanalytics-0.4.2.dev201512019643.tar.gz trustedanalytics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "import trustedanalytics as atk\n",
+    "\n",
+    "print \"ATK installation path = %s\" % (atk.__path__)\n",
+    "\n",
+    "# Replace the server uri value with your ATK instance uri\n",
+    "\n",
+    "atk.server.uri = 'demo-atk-c07d8047.demotrustedanalytics.com'\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "atk.create_credentials_file('atk-cred.creds')  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "atk.connect(r'atk-cred.creds')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/src/analytics/Netflow_Demo_TestDrive.ipynb
+++ b/src/analytics/Netflow_Demo_TestDrive.ipynb
@@ -1,0 +1,554 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##Import the necessary libraries and connect to the server"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import csv\n",
+    "import json\n",
+    "import numpy as np\n",
+    "import socket,struct\n",
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline\n",
+    "import time as time\n",
+    "import itertools\n",
+    "import pandas as pd\n",
+    "\n",
+    "#Unique prefix to make sure my names don't conflict with yours\n",
+    "MY_SUFFIX = \"_\" + os.getcwd().split('/')[-1] \n",
+    "\n",
+    "print \"MY_SUFFIX =\",MY_SUFFIX"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cleanup objects prior to next run"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "drop_objects = True\n",
+    "\n",
+    "def drop(pattern):    \n",
+    "    map(atk.drop_frames, filter(lambda x: not x.find(pattern) < 0, atk.get_frame_names()))\n",
+    "    map(atk.drop_graphs, filter(lambda x: not x.find(pattern) < 0, atk.get_graph_names()))\n",
+    "    map(atk.drop_models, filter(lambda x: not x.find(pattern) < 0, atk.get_model_names()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Connect to ATK REST server"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import trustedanalytics as atk\n",
+    "import trustedanalytics.core.admin as admin\n",
+    "\n",
+    "print \"ATK installation path = %s\" % (atk.__path__)\n",
+    "\n",
+    "# Make sure you created the credential file before connecting to ATK\n",
+    "# Replace the server uri value with your ATK instance uri\n",
+    "\n",
+    "\n",
+    "atk.server.uri = 'demo-atk-c07d8047.demotrustedanalytics.com'\n",
+    "atk.connect(r'atk-cred.creds')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cleanup objects prior to next run"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "#Clearing out old frames and graphs:\n",
+    "\n",
+    "reference = MY_SUFFIX ### Please ensure each user uses different value here\n",
+    "score = reference\n",
+    "\n",
+    "if drop_objects == True:\n",
+    "    drop('network_edges_'+reference)\n",
+    "    drop('network_graph_'+reference)    \n",
+    "    drop('bytes_out_'+score)\n",
+    "    drop('bytes_in_'+score)\n",
+    "    drop('bytes_in_out_'+score)\n",
+    "    drop('ip_summary_frame_'+score)\n",
+    "    drop('svmModel_' + reference)\n",
+    "    admin.drop_stale(\"24 hours\")\n",
+    "    admin.finalize_dropped()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Now, read in the data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "dataset = \"hdfs://nameservice1/org/intel/hdfsbroker/userspace/9ab8aba2-c966-4518-8ed2-3378db90946c/a3117a34-306d-47cc-9fd9-f3aa4471526e/000000_1\"\n",
+    "week2_nf_schema=[('TimeSeconds', atk.float64),\n",
+    "                 ('tstart', str),\n",
+    "                 ('dateTimeStr', atk.float64),\n",
+    "                 ('protocol', str),\n",
+    "                 ('proto', str),\n",
+    "                 ('sip', str),\n",
+    "                 ('dip', str),\n",
+    "                 ('sport', atk.int64),\n",
+    "                 ('dport', atk.int64),\n",
+    "                 ('flag', atk.int64),\n",
+    "                 ('fwd', atk.int64),\n",
+    "                 ('tdur', atk.int64),\n",
+    "                 ('firstSeenSrcPayloadBytes', atk.int64),\n",
+    "                 ('firstSeenDestPayloadBytes', atk.int64),\n",
+    "                 ('ibyt', atk.int64),\n",
+    "                 ('obyt', atk.int64),\n",
+    "                 ('ipkt', atk.int64),\n",
+    "                 ('opkt', atk.int64),\n",
+    "                 ('recordForceOut', atk.int64)]\n",
+    "\n",
+    "real_netflow = atk.Frame(atk.CsvFile(dataset, week2_nf_schema,  skip_header_lines=1))\n",
+    "if drop_objects == True:\n",
+    "    drop('real_netflow_'+reference)\n",
+    "real_netflow.name='real_netflow_'+reference\n",
+    "\n",
+    "real_netflow.inspect(wrap=10, round=4, width=100)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "## Add Columns for date/time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def get_time(row):\n",
+    "    x = row.tstart.split(\" \")\n",
+    "    date = x[0]\n",
+    "    time = x[1]\n",
+    "    y = time.split(\":\")\n",
+    "    hour = atk.float64(y[0])\n",
+    "    minute = atk.float64(y[1])\n",
+    "    numeric_time = hour + minute/60.0\n",
+    "    return [date, time, hour, minute, numeric_time]\n",
+    "\n",
+    "real_netflow.add_columns(get_time, [('date',str), \n",
+    "                                    ('time',str), \n",
+    "                                    ('hour', atk.float64), \n",
+    "                                    ('minute', atk.float64), \n",
+    "                                    ('numeric_time', atk.float64)], \n",
+    "                         columns_accessed=['tstart'])\n",
+    "\n",
+    "real_netflow.inspect(wrap=10, round=4, width=100,\n",
+    "                     columns=['date', 'time', 'hour', 'minute', 'numeric_time'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Build a Graph for computing graph statistics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "network_edges = real_netflow.group_by(['sip', 'dip'], atk.agg.count)\n",
+    "if drop_objects == True:\n",
+    "    drop('network_edges_'+reference)\n",
+    "network_edges.name = 'network_edges_'+reference\n",
+    "\n",
+    "network_graph = atk.Graph()\n",
+    "if drop_objects == True:\n",
+    "    drop('network_graph_'+reference)\n",
+    "network_graph.name = 'network_graph_'+reference\n",
+    "network_graph.define_vertex_type('IP')\n",
+    "network_graph.define_edge_type('Connection', 'IP', 'IP', directed=False)\n",
+    "network_graph.edges['Connection'].add_edges(network_edges, 'sip', 'dip', ['count'], create_missing_vertices = True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Compute bytes in and bytes out"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "bytes_out = real_netflow.group_by(['sip'], atk.agg.count, {'ibyt': atk.agg.sum})\n",
+    "bytes_out.rename_columns({'ibyt_SUM': 'obyt_SUM', 'count': 'outgoing_connections'})\n",
+    "\n",
+    "if drop_objects == True:\n",
+    "    drop('bytes_out_'+score)\n",
+    "bytes_out.name = 'bytes_out_'+score\n",
+    "bytes_in = real_netflow.group_by(['dip'], {'ibyt': atk.agg.sum})\n",
+    "\n",
+    "if drop_objects == True:\n",
+    "    drop('bytes_in_'+score)\n",
+    "bytes_in.name = 'bytes_in_'+score\n",
+    "bytes_in_out = bytes_out.join(bytes_in, left_on='sip', right_on='dip', how='inner')\n",
+    "\n",
+    "if drop_objects == True:\n",
+    "    drop('bytes_in_out_'+score)\n",
+    "bytes_in_out.name = 'bytes_in_out_'+score\n",
+    "bytes_in_out.add_columns(lambda row: [np.log(row.ibyt_SUM), np.log(row.obyt_SUM)], \n",
+    "                         [('ln_ibyt_SUM', atk.float64), ('ln_obyt_SUM', atk.float64)])\n",
+    "\n",
+    "bytes_in_out.inspect(wrap=10, round=4, width=100)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Compute Weighted/Unweighted Degree Counts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print 'Compute degree count:'\n",
+    "unweighted_degree_frame = network_graph.annotate_degrees('degree', 'undirected')['IP']\n",
+    "\n",
+    "print 'Compute weighted degree count:'\n",
+    "weighted_degree_frame = network_graph.annotate_weighted_degrees('weighted_degree', 'undirected', \n",
+    "                                                                      edge_weight_property = 'count')['IP']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Compute Summary frame and Download it to Pandas"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "ip_summary_frame_intermidiate = bytes_in_out.join(weighted_degree_frame, left_on='sip', right_on='sip', how='inner')\n",
+    "ip_summary_frame = ip_summary_frame_intermidiate.join(unweighted_degree_frame, left_on='sip', right_on='sip', how='inner')\n",
+    "\n",
+    "if drop_objects == True:\n",
+    "    drop('ip_summary_frame_'+score)\n",
+    "ip_summary_frame.name = 'ip_summary_frame_'+score\n",
+    "#ip_summary_frame.drop_columns(['dip', '_vid_L', '_vid_R', '_label_L', '_label_R', 'sip_L', 'sip_R'])\n",
+    "ip_summary_frame.add_columns(lambda row: [row.ibyt_SUM + row.obyt_SUM, \n",
+    "                                          np.log(row.ibyt_SUM + row.obyt_SUM),\n",
+    "                                          np.log(row.degree),\n",
+    "                                          np.log(row.weighted_degree)], \n",
+    "                             [('total_traffic', atk.float64),\n",
+    "                             ('ln_total_traffic', atk.float64),\n",
+    "                             ('ln_degree', atk.float64),\n",
+    "                             ('ln_weighted_degree', atk.float64)])\n",
+    "ip_summary_frame.rename_columns({'sip': 'ip'})\n",
+    "print ip_summary_frame.inspect(wrap=10, round=4, width=100)\n",
+    "ip_summary_frame_pd = ip_summary_frame.download(ip_summary_frame.row_count)\n",
+    "ip_summary_frame_pd.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Compute histogram bins"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "outgoing_connections_bins = 100\n",
+    "ln_ibyt_SUM_bins = 100\n",
+    "ln_obyt_SUM_bins = 100\n",
+    "ln_total_traffic_bins = 100\n",
+    "weighted_degree_bins = 100\n",
+    "degree_bins = 100\n",
+    "\n",
+    "def plot_hist(histogram):\n",
+    "    plt.bar(histogram.cutoffs[:-1], histogram.hist, width = histogram.cutoffs[1]-histogram.cutoffs[0])\n",
+    "    plt.xlim(min(histogram.cutoffs), max(histogram.cutoffs))\n",
+    "\n",
+    "histograms = {}\n",
+    "histograms['outgoing_connections'] = ip_summary_frame.histogram(\n",
+    "    column_name = \"outgoing_connections\", num_bins=outgoing_connections_bins)\n",
+    "histograms['ln_ibyt_SUM'] = ip_summary_frame.histogram(column_name = \"ln_ibyt_SUM\", num_bins=ln_ibyt_SUM_bins)\n",
+    "histograms['ln_obyt_SUM'] = ip_summary_frame.histogram(column_name = \"ln_obyt_SUM\", num_bins=ln_obyt_SUM_bins)\n",
+    "histograms['ln_total_traffic'] = ip_summary_frame.histogram(column_name = \"ln_total_traffic\", num_bins=ln_total_traffic_bins)\n",
+    "histograms['ln_weighted_degree'] = ip_summary_frame.histogram(column_name = \"ln_weighted_degree\", num_bins=weighted_degree_bins)\n",
+    "histograms['ln_degree'] = ip_summary_frame.histogram(column_name = \"ln_degree\", num_bins=degree_bins)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plot histograms"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "plot_hist(histograms['outgoing_connections'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "plot_hist(histograms['ln_ibyt_SUM'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "plot_hist(histograms['ln_obyt_SUM'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "plot_hist(histograms['ln_total_traffic'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "plot_hist(histograms['ln_weighted_degree'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "plot_hist(histograms['ln_degree'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Make a scatter plot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# import the scatter_matrix functionality\n",
+    "from pandas.tools.plotting import scatter_matrix\n",
+    "\n",
+    "# define colors list, to be used to plot survived either red (=0) or green (=1)\n",
+    "colors=['yellow','green']\n",
+    "\n",
+    "# make a scatter plot\n",
+    "df = pd.DataFrame(ip_summary_frame.take(ip_summary_frame.row_count, \n",
+    "                                        columns=[\"ln_ibyt_SUM\", \"ln_obyt_SUM\", \"ln_degree\", \"ln_weighted_degree\"]), \n",
+    "                  columns=[\"ln_ibyt_SUM\", \"ln_obyt_SUM\", \"ln_degree\", \"ln_weighted_degree\"])\n",
+    "\n",
+    "scatter_matrix(df, figsize=[20,20],marker='x',\n",
+    "               c=df.ln_degree.apply(lambda x: colors[1]))\n",
+    "\n",
+    "df.info()\n",
+    "print ip_summary_frame.inspect(wrap=10, round=4, width=100)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create and train an SVM model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "ip_summary_frame = atk.get_frame('ip_summary_frame_' + reference)\n",
+    "ip_summary_frame.add_columns(lambda row: '1', ('label', atk.float64))\n",
+    "\n",
+    "if drop_objects == True:\n",
+    "    drop('svmModel_' + reference)\n",
+    "SVM_model = atk.LibsvmModel('svmModel_' + reference)\n",
+    "SVM_model.train(ip_summary_frame, 'label', \n",
+    "                [\"ln_ibyt_SUM\", \"ln_obyt_SUM\", \"ln_degree\", \"ln_weighted_degree\"],\n",
+    "                nu=0.5, svm_type=2)\n",
+    "\n",
+    "scored_frame = SVM_model.predict(ip_summary_frame, \n",
+    "                                 [\"ln_ibyt_SUM\", \"ln_obyt_SUM\", \"ln_degree\", \"ln_weighted_degree\"])\n",
+    "\n",
+    "scored_frame_group_by = scored_frame.group_by(\"predicted_label\", atk.agg.count)\n",
+    "scored_frame_group_by.inspect(wrap=10, round=4, width=100)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Download scatter frame to Pandas"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "df = pd.DataFrame(scored_frame.take(ip_summary_frame.row_count, \n",
+    "                                    columns=[\"ln_ibyt_SUM\", \"ln_obyt_SUM\", \"ln_degree\", \"ln_weighted_degree\", \"predicted_label\"]), \n",
+    "                  columns=[\"ln_ibyt_SUM\", \"ln_obyt_SUM\", \"ln_degree\", \"ln_weighted_degree\", \"predicted_label\"])\n",
+    "\n",
+    "#scored_frame_pd = scored_frame.download(scored_frame.row_count)\n",
+    "# import the scatter_matrix functionality\n",
+    "from pandas.tools.plotting import scatter_matrix\n",
+    "\n",
+    "# define colors list, to be used to plot survived either red (=0) or green (=1)\n",
+    "colors=['red','green']\n",
+    "\n",
+    "# make a scatter plot\n",
+    "scatter_matrix(df, figsize=[20,20],marker='x',\n",
+    "               c=df.predicted_label.apply(lambda x: (colors[1] if x == 1 else colors[0])))\n",
+    "\n",
+    "df.info()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
In TestDrive, I used the stock Docker container to create a new container that already loads the Jupyter notebook files for the end-user.  In addition, there is a slight change I needed to make to the Netflow_Demo notebook, due to some limitations in ATK with regard to running in a multitenant environment.

When the Jupyter container is started in TestDrive, it downloads these files - they are not built into the image.  This is so that if the demo files need to change, we do not have to redeploy the docker container.  Also, if the original notebooks are changed without first testing them in TestDrive, it could negatively impact the user experience of the labs.

Please let me know if you have any questions or concerns.  Thanks.
Jeremy
